### PR TITLE
Update Key Vault access policy, fetch common secrets from Key Vault

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build "${{inputs.project-to-build}}" --no-restore --configuration Release
+        run: dotnet build "${{inputs.project-to-build}}" --no-restore --configuration Release /p:BuildNumber=${{ github.run_number }} /p:GITHUB_ACTIONS=true
 
       - name: Test
         if: inputs.project-to-test != ''

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet restore
 
       - name: Package project
-        run: dotnet pack "${{inputs.project-to-pack}}" --configuration Release --output ./unsigned
+        run: dotnet pack "${{inputs.project-to-pack}}" --configuration Release --output ./unsigned /p:BuildNumber=${{ github.run_number }} /p:GITHUB_ACTIONS=true
 
       - name: Verify Package Metadata
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,7 @@ jobs:
       if: inputs.dry_run == false
       run: |
         $signedFileName = ${{ steps.find-signed-package.outputs.fileName }}
-        nuget push signed/$fileName `
+        nuget push signed/$signedFileName `
           -Source https://api.nuget.org/v3/index.json `
           -ApiKey ${{ steps.get-api-key.outputs.nuget-api-key }} `
           -Verbosity detailed `

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,22 @@ name: Publish
 on:
   workflow_call:
     secrets:
-      api_key:
+      AAD_CLIENT_ID:
+        required: true
+      AAD_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+      KEY_VAULT_NAME:
         required: true
     inputs:
       dry_run:
         required: false
         type: boolean
         default: false
+
+permissions:
+  id-token: write
 
 jobs:
   Publish:
@@ -22,20 +31,94 @@ jobs:
         name: signed
         path: signed
 
+    - name: Checkout microsoft/digitalworkplace-workflows
+      uses: actions/checkout@v3
+      with:
+        repository: microsoft/digitalworkplace-workflows
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: digitalworkplace-workflows
+        ref: v3.1-beta
+
+    - name: Get runner's IP address
+      id: ip-address
+      run: |
+        . .\digitalworkplace-workflows\scripts\get-externalipaddress.ps1
+        Get-ExternalIPAddress "ip-address"
+      shell: pwsh
+
+    - name: Azure login
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AAD_CLIENT_ID }}
+        tenant-id: ${{ secrets.AAD_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Allow runner's IP address in Key Vault
+      run: |
+        az keyvault network-rule add `
+          --name ${{ secrets.KEY_VAULT_NAME }} `
+          --ip-address ${{ steps.ip-address.outputs.ip-address }} `
+          --output none
+      shell: pwsh
+
+    - name: Get NuGet API key from Key Vault
+      id: get-api-key
+      run: |
+        $env:AZURE_SUBSCRIPTION_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+        $env:KEY_VAULT_NAME = "${{ secrets.KEY_VAULT_NAME }}"
+        . .\digitalworkplace-workflows\scripts\get-secret.ps1
+        Get-Secret -secretName "github-publishing-nuget-api-key" -outputName "nuget-api-key"
+      shell: pwsh
+
+    - name: Remove runner's IP address from Key Vault
+      run: |
+        az keyvault network-rule remove `
+          --name ${{ secrets.KEY_VAULT_NAME }} `
+          --ip-address ${{ steps.ip-address.outputs.ip-address }} `
+          --output none
+      shell: pwsh
+      if: always()
+
+    - name: Azure logout
+      run: az logout
+      if: always()
+
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1
+
+    - name: Find signed package
+      id: find-signed-package
+      run: |
+        $signedFileName = (Get-ChildItem -Recurse -Path signed -Filter *.nupkg | Select-Object -Property Name -First 1).Name
+        Write-Host "Signed file name found: $signedFileName"
+        Write-Output "$fileName=$signedFileName" >> $env:GITHUB_OUTPUT
+      shell: pwsh
 
     - name: Push Package Dry Run
       if: inputs.dry_run == true
       run: |
-        $signedFileName = (Get-ChildItem -Recurse -Path signed -Filter *.nupkg | Select-Object -Property Name -First 1).Name
+        $signedFileName = ${{ steps.find-signed-package.outputs.fileName }}
+        Write-Host "Signed file name (confirmation): $signedFileName"
         Write-Host "Dry-run enabled. Not pushing to NuGet."
-        Write-Host "Signed Filename found: $signedFileName"
+
+        $response = Invoke-WebRequest `
+          https://www.nuget.org/api/v2/package/create-verification-key/Microsoft.DigitalWorkplace.DigitalTwins.Models.Generator/0.2.0 `
+          -Headers @{'X-NUGET-APIKEY' = '${{ steps.get-api-key.outputs.nuget-api-key }}'} `
+          -Method 'POST'
+        if ($response.StatusCode -eq 200) {
+          Write-Host "NuGet API key is valid."
+        } else {
+          Write-Host "::error::NuGet API key is invalid."
+        }
       shell: pwsh
 
     - name: Push Package
       if: inputs.dry_run == false
       run: |
-        $signedFileName = (Get-ChildItem -Recurse -Path signed -Filter *.nupkg | Select-Object -Property Name -First 1).Name
-        nuget push signed/$fileName -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.api_key }} -Verbosity detailed -NonInteractive
+        $signedFileName = ${{ steps.find-signed-package.outputs.fileName }}
+        nuget push signed/$fileName `
+          -Source https://api.nuget.org/v3/index.json `
+          -ApiKey ${{ steps.get-api-key.outputs.nuget-api-key }} `
+          -Verbosity detailed `
+          -NonInteractive
       shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,6 @@ jobs:
         repository: microsoft/digitalworkplace-workflows
         token: ${{ secrets.GITHUB_TOKEN }}
         path: digitalworkplace-workflows
-        ref: v3.1-beta
 
     - name: Get runner's IP address
       id: ip-address

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -3,25 +3,13 @@ name: Sign
 on:
   workflow_call:
     secrets:
-      azure_login_client_id:
+      AAD_CLIENT_ID:
         required: true
-      aad_tenant_id:
+      AAD_TENANT_ID:
         required: true
-      azure_subscription_id:
+      AZURE_SUBSCRIPTION_ID:
         required: true
-      storage_account_name:
-        required: true
-      container_name:
-        required: true
-      key_vault_name:
-        required: true
-      esrp_aad_client_id:
-        required: true
-      esrp_aad_auth_cert:
-        required: true
-      esrp_signing_cert:
-        required: true
-      esrp_signing_cert_thumbprint:
+      KEY_VAULT_NAME:
         required: true
 
 permissions:
@@ -38,21 +26,59 @@ jobs:
         name: unsigned
         path: unsigned
 
+    - name: Checkout microsoft/digitalworkplace-workflows
+      uses: actions/checkout@v3
+      with:
+        repository: microsoft/digitalworkplace-workflows
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: digitalworkplace-workflows
+
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1
 
     - name: Azure Login
       uses: azure/login@v1
       with:
-        client-id: ${{ secrets.azure_login_client_id }}
-        tenant-id: ${{ secrets.aad_tenant_id }}
-        subscription-id: ${{ secrets.azure_subscription_id }}
+        client-id: ${{ secrets.AAD_CLIENT_ID }}
+        tenant-id: ${{ secrets.AAD_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Get secrets from Key Vault
+      id: get-secrets
+      run: |
+        $env:AZURE_SUBSCRIPTION_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+        $env:KEY_VAULT_NAME = "${{ secrets.KEY_VAULT_NAME }}"
+        . .\digitalworkplace-workflows\scripts\get-secret.ps1
+
+        $secrets = [ordered]@{
+          "github-signing-storage-account-name" = "storage-account-name"
+          "github-signing-container-name" = "container-name"
+          "github-signing-esrp-aad-client-id" = "esrp-aad-client-id"
+          "github-signing-esrp-aad-auth-cert-secret-name" = "esrp-aad-auth-cert-secret-name"
+          "github-signing-esrp-signing-cert-secret-name" = "esrp-signing-cert-secret-name"
+          "github-signing-esrp-signing-cert-thumbprint" = "esrp-signing-cert-thumbprint"
+          "github-signing-esrp-client-blob-name" = "esrp-client-blob-name"
+        }
+
+        foreach ($Key in $secrets.Keys) {
+          Get-Secret -secretName $Key -outputName $secrets[$Key]
+        }
+      shell: pwsh
 
     - name: Run Signing Script
       run: |
-        $url = "https://raw.githubusercontent.com/microsoft/digitalworkplace-workflows/main/scripts/sign.ps1"
-        Invoke-WebRequest $url -OutFile sign.ps1
-        .\sign.ps1 ${{ secrets.esrp_aad_client_id }} ${{ github.workspace }} ${{ secrets.azure_subscription_id }} ${{ secrets.storage_account_name }} ${{ secrets.container_name }} ${{ secrets.key_vault_name }} ${{ secrets.esrp_aad_auth_cert }} ${{ secrets.esrp_signing_cert }} ${{ secrets.esrp_signing_cert_thumbprint }}
+        .\digitalworkplace-workflows\scripts\sign.ps1 `
+          -esrpSigningAadClientId '${{ steps.get-secrets.outputs.esrp-aad-client-id }}' `
+          -workspace '${{ github.workspace }}' `
+          -azureSubscriptionId '${{ secrets.AZURE_SUBSCRIPTION_ID }}' `
+          -aadTenantId '${{ secrets.AAD_TENANT_ID }}' `
+          -storageAccountName '${{ steps.get-secrets.outputs.storage-account-name }}' `
+          -containerName '${{ steps.get-secrets.outputs.container-name }}' `
+          -keyVaultName '${{ secrets.KEY_VAULT_NAME }}' `
+          -esrpAadAuthCertSecretName '${{ steps.get-secrets.outputs.esrp-aad-auth-cert-secret-name }}' `
+          -esrpSigningCertSecretName '${{ steps.get-secrets.outputs.esrp-signing-cert-secret-name }}' `
+          -esrpSigningCertFingerprint '${{ steps.get-secrets.outputs.esrp-signing-cert-thumbprint }}' `
+          -esrpClientBlobName '${{ steps.get-secrets.outputs.esrp-client-blob-name }}'
       shell: pwsh
 
     - name: Azure logout

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -33,6 +33,13 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: digitalworkplace-workflows
 
+    - name: Get runner's IP address
+      id: ip-address
+      run: |
+        . .\digitalworkplace-workflows\scripts\get-externalipaddress.ps1
+        Get-ExternalIPAddress "ip-address"
+      shell: pwsh
+
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1
 
@@ -42,6 +49,14 @@ jobs:
         client-id: ${{ secrets.AAD_CLIENT_ID }}
         tenant-id: ${{ secrets.AAD_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Allow runner's IP address in Key Vault
+      run: |
+        az keyvault network-rule add `
+          --name ${{ secrets.KEY_VAULT_NAME }} `
+          --ip-address ${{ steps.ip-address.outputs.ip-address }} `
+          --output none
+      shell: pwsh
 
     - name: Get secrets from Key Vault
       id: get-secrets
@@ -80,6 +95,15 @@ jobs:
           -esrpSigningCertFingerprint '${{ steps.get-secrets.outputs.esrp-signing-cert-thumbprint }}' `
           -esrpClientBlobName '${{ steps.get-secrets.outputs.esrp-client-blob-name }}'
       shell: pwsh
+
+    - name: Remove runner's IP address from Key Vault
+      run: |
+        az keyvault network-rule remove `
+          --name ${{ secrets.KEY_VAULT_NAME }} `
+          --ip-address ${{ steps.ip-address.outputs.ip-address }} `
+          --output none
+      shell: pwsh
+      if: always()
 
     - name: Azure logout
       run: az logout

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -111,6 +111,14 @@ jobs:
       run: az logout
       if: always()
 
+    - name: Copy snupkg file to signed folder
+      run: |
+        Copy-Item `
+          -Path unsigned\*.snupkg `
+          -Destination signed\ `
+          -Force
+      shell: pwsh
+
     - name: Upload Signed Packages
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -61,8 +61,6 @@ jobs:
     - name: Get secrets from Key Vault
       id: get-secrets
       run: |
-        $env:AZURE_SUBSCRIPTION_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-        $env:KEY_VAULT_NAME = "${{ secrets.KEY_VAULT_NAME }}"
         . .\digitalworkplace-workflows\scripts\get-secret.ps1
 
         $secrets = [ordered]@{
@@ -76,7 +74,11 @@ jobs:
         }
 
         foreach ($Key in $secrets.Keys) {
-          Get-Secret -secretName $Key -outputName $secrets[$Key]
+          Get-Secret `
+            -subscriptionId ${{ secrets.AZURE_SUBSCRIPTION_ID }} `
+            -keyVaultName ${{ secrets.KEY_VAULT_NAME }} `
+            -secretName $Key `
+            -outputName $secrets[$Key]
         }
       shell: pwsh
 
@@ -85,7 +87,7 @@ jobs:
         .\digitalworkplace-workflows\scripts\sign.ps1 `
           -esrpSigningAadClientId '${{ steps.get-secrets.outputs.esrp-aad-client-id }}' `
           -workspace '${{ github.workspace }}' `
-          -azureSubscriptionId '${{ secrets.AZURE_SUBSCRIPTION_ID }}' `
+          -subscriptionId '${{ secrets.AZURE_SUBSCRIPTION_ID }}' `
           -aadTenantId '${{ secrets.AAD_TENANT_ID }}' `
           -storageAccountName '${{ steps.get-secrets.outputs.storage-account-name }}' `
           -containerName '${{ steps.get-secrets.outputs.container-name }}' `

--- a/scripts/get-externalipaddress.ps1
+++ b/scripts/get-externalipaddress.ps1
@@ -1,0 +1,12 @@
+function Get-ExternalIPAddress {
+    param (
+        [Parameter(Mandatory=$true)] [string]$outputName
+    )
+    $ipAddress = (Invoke-WebRequest -Uri 'https://api.ipify.org').Content
+
+    Write-Output "::add-mask::$ipAddress"
+    Write-Output "$outputName=$ipAddress" >> $env:GITHUB_OUTPUT
+
+    $redacted = $ipAddress -replace "(?!\d+\.\d+\.)\d", "*"
+    Write-Output "GitHub Action runner's external IP address: $redacted"
+}

--- a/scripts/get-secret.ps1
+++ b/scripts/get-secret.ps1
@@ -1,11 +1,13 @@
 function Get-Secret {
     param (
+        [Parameter(Mandatory=$true)] [string]$subscriptionId,
+        [Parameter(Mandatory=$true)] [string]$keyVaultName,
         [Parameter(Mandatory=$true)] [string]$secretName,
         [Parameter(Mandatory=$true)] [string]$outputName
     )
     $secret = az keyvault secret show `
-                --subscription $env:AZURE_SUBSCRIPTION_ID `
-                --vault-name $env:KEY_VAULT_NAME `
+                --subscription $subscriptionId `
+                --vault-name $keyVaultName `
                 --name $secretName `
                 | ConvertFrom-Json
 

--- a/scripts/get-secret.ps1
+++ b/scripts/get-secret.ps1
@@ -1,0 +1,17 @@
+function Get-Secret {
+    param (
+        [Parameter(Mandatory=$true)] [string]$secretName,
+        [Parameter(Mandatory=$true)] [string]$outputName
+    )
+    $secret = az keyvault secret show `
+                --subscription $env:AZURE_SUBSCRIPTION_ID `
+                --vault-name $env:KEY_VAULT_NAME `
+                --name $secretName `
+                | ConvertFrom-Json
+
+    # Mask the secret in logs
+    Write-Output "::add-mask::$($secret.value)"
+
+    # Output the secret for use in later steps
+    Write-Output "$outputName=$($secret.value)" >> $env:GITHUB_OUTPUT
+}

--- a/scripts/sign.ps1
+++ b/scripts/sign.ps1
@@ -1,16 +1,16 @@
 param(
-    [Parameter(Mandatory=$true)] [string]$signingClientId,
+    [Parameter(Mandatory=$true)] [string]$esrpSigningAadClientId,
     [Parameter(Mandatory=$true)] [string]$workspace,
-    [Parameter(Mandatory=$true)] [string]$subscriptionId,
-    [Parameter(Mandatory=$true)] [string]$tenantId,
-    [Parameter(Mandatory=$true)] [string]$storage_name,
-    [Parameter(Mandatory=$true)] [string]$container_name,
-    [Parameter(Mandatory=$true)] [string]$vault_name,
-    [Parameter(Mandatory=$true)] [string]$aad_cert,
-    [Parameter(Mandatory=$true)] [string]$sign_cert,
-    [Parameter(Mandatory=$true)] [string]$signing_cert_fingerprint,
-    [Parameter(Mandatory=$false)] [switch]$user_login,
-    [Parameter(Mandatory=$false)] [string]$esrp_client_blob_name = "microsoft.esrpclient.1.2.76.zip"
+    [Parameter(Mandatory=$true)] [string]$azureSubscriptionId,
+    [Parameter(Mandatory=$true)] [string]$aadTenantId,
+    [Parameter(Mandatory=$true)] [string]$storageAccountName,
+    [Parameter(Mandatory=$true)] [string]$containerName,
+    [Parameter(Mandatory=$true)] [string]$keyVaultName,
+    [Parameter(Mandatory=$true)] [string]$esrpAadAuthCertSecretName,
+    [Parameter(Mandatory=$true)] [string]$esrpSigningCertSecretName,
+    [Parameter(Mandatory=$true)] [string]$esrpSigningCertFingerprint,
+    [Parameter(Mandatory=$true)] [string]$esrpClientBlobName,
+    [Parameter(Mandatory=$false)] [switch]$userLogin
 )
 
 if ($workspace -notmatch '\\\\')
@@ -30,10 +30,10 @@ if ([string]::IsNullOrWhiteSpace($fileName)) {
 }
 
 Write-Host "Found unsigned nupkg: $fileName"
-if ($user_login) {
+if ($userLogin) {
     Write-Host 'Logging into Azure.'
     az login --output none
-    az account set --subscription $subscriptionId
+    az account set --subscription $azureSubscriptionId
 }
 
 if (Test-Path 'signed') {
@@ -48,16 +48,16 @@ $authJson = @"
 {
     "Version": "1.0.0",
     "AuthenticationType": "AAD_CERT",
-    "TenantId": "$tenantId",
-    "signingClientId": "$signingClientId",
+    "TenantId": "$aadTenantId",
+    "ClientId": "$esrpSigningAadClientId",
     "AuthCert": {
-        "SubjectName": "CN=$signingClientId.microsoft.com",
+        "SubjectName": "CN=$esrpSigningAadClientId.microsoft.com",
         "StoreLocation": "LocalMachine",
         "StoreName": "My",
         "SendX5c": "true"
     },
     "RequestSigningCert": {
-        "SubjectName": "CN=$signingClientId",
+        "SubjectName": "CN=$esrpSigningAadClientId",
         "StoreLocation": "LocalMachine",
         "StoreName": "My"
     }
@@ -103,7 +103,7 @@ Out-File -FilePath .\input.json -InputObject $inputJson
 Write-Host 'Done.'
 try {
     Write-Host 'Downloading ESRP Client.'
-    az storage blob download --auth-mode login --subscription  $subscriptionId --account-name $storage_name -c $container_name -n $esrp_client_blob_name -f esrp.zip
+    az storage blob download --auth-mode login --subscription  $azureSubscriptionId --account-name $storageAccountName -c $containerName -n $esrpClientBlobName -f esrp.zip
     if (Test-Path 'esrp.zip') {
         Write-Host 'Done.'
     } else {
@@ -115,10 +115,10 @@ try {
     Write-Host 'Done.'
     Write-Host 'Downloading & Installing Certifictes.'
     Remove-Item cert.pfx -ErrorAction SilentlyContinue
-    az keyvault secret download --subscription $subscriptionId --vault-name $vault_name --name $aad_cert -f cert.pfx
+    az keyvault secret download --subscription $azureSubscriptionId --vault-name $keyVaultName --name $esrpAadAuthCertSecretName -f cert.pfx
     certutil -silent -f -importpfx cert.pfx
     Remove-Item cert.pfx
-    az keyvault secret download --subscription $subscriptionId --vault-name $vault_name --name $sign_cert -f cert.pfx
+    az keyvault secret download --subscription $azureSubscriptionId --vault-name $keyVaultName --name $esrpSigningCertSecretName -f cert.pfx
     certutil -silent -f -importpfx cert.pfx
     Remove-Item cert.pfx
     Write-Host 'Done.'
@@ -136,7 +136,7 @@ try {
 
     Write-Host 'Done. Signing Complete.'
     Write-Host 'Verifying signatures with NuGet.'
-    $result = nuget verify -Signatures signed/$signedFileName -CertificateFingerprint $signing_cert_fingerprint
+    $result = nuget verify -Signatures signed/$signedFileName -CertificateFingerprint $esrpSigningCertFingerprint
     Write-Host $result
     $validationFailString = $result | Where-Object { $_ -match 'Package signature validation failed.'}
     $noPackageFailString = $result | Where-Object { $_ -match 'File does not exist'}
@@ -151,7 +151,7 @@ try {
 } catch {
     throw
 } finally {
-    if ($user_login) {
+    if ($userLogin) {
         az logout
     }
 }

--- a/scripts/sign.ps1
+++ b/scripts/sign.ps1
@@ -1,7 +1,7 @@
 param(
     [Parameter(Mandatory=$true)] [string]$esrpSigningAadClientId,
     [Parameter(Mandatory=$true)] [string]$workspace,
-    [Parameter(Mandatory=$true)] [string]$azureSubscriptionId,
+    [Parameter(Mandatory=$true)] [string]$subscriptionId,
     [Parameter(Mandatory=$true)] [string]$aadTenantId,
     [Parameter(Mandatory=$true)] [string]$storageAccountName,
     [Parameter(Mandatory=$true)] [string]$containerName,
@@ -33,7 +33,7 @@ Write-Host "Found unsigned nupkg: $fileName"
 if ($userLogin) {
     Write-Host 'Logging into Azure.'
     az login --output none
-    az account set --subscription $azureSubscriptionId
+    az account set --subscription $subscriptionId
 }
 
 if (Test-Path 'signed') {
@@ -103,7 +103,7 @@ Out-File -FilePath .\input.json -InputObject $inputJson
 Write-Host 'Done.'
 try {
     Write-Host 'Downloading ESRP Client.'
-    az storage blob download --auth-mode login --subscription  $azureSubscriptionId --account-name $storageAccountName -c $containerName -n $esrpClientBlobName -f esrp.zip
+    az storage blob download --auth-mode login --subscription  $subscriptionId --account-name $storageAccountName -c $containerName -n $esrpClientBlobName -f esrp.zip
     if (Test-Path 'esrp.zip') {
         Write-Host 'Done.'
     } else {
@@ -115,10 +115,10 @@ try {
     Write-Host 'Done.'
     Write-Host 'Downloading & Installing Certifictes.'
     Remove-Item cert.pfx -ErrorAction SilentlyContinue
-    az keyvault secret download --subscription $azureSubscriptionId --vault-name $keyVaultName --name $esrpAadAuthCertSecretName -f cert.pfx
+    az keyvault secret download --subscription $subscriptionId --vault-name $keyVaultName --name $esrpAadAuthCertSecretName -f cert.pfx
     certutil -silent -f -importpfx cert.pfx
     Remove-Item cert.pfx
-    az keyvault secret download --subscription $azureSubscriptionId --vault-name $keyVaultName --name $esrpSigningCertSecretName -f cert.pfx
+    az keyvault secret download --subscription $subscriptionId --vault-name $keyVaultName --name $esrpSigningCertSecretName -f cert.pfx
     certutil -silent -f -importpfx cert.pfx
     Remove-Item cert.pfx
     Write-Host 'Done.'


### PR DESCRIPTION
- New `Get-Secret` function to fetch secrets from a Key Vault.
- New `Get-ExternalIPAddress` function to fetch the runner's IP address.
- Update `sign.ps1` to clarify the parameters.
- Update `Sign` and `Publish` workflows:
  - Use `Get-ExternalIPAddress` to add the runner's IP address to the network rules and later remove it.
  - Fetch secrets that are common using `Get-Secret`.
- Update `Build` and `Pack` workflows to better support versioning.

Fixes #7.