### PR TITLE
Users/shdeb/fix release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         az keyvault network-rule add `
           --name ${{ secrets.KEY_VAULT_NAME }} `
-          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_RESOURCE_GROUP }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh
@@ -76,7 +76,7 @@ jobs:
       run: |
         az keyvault network-rule remove `
           --name ${{ secrets.KEY_VAULT_NAME }} `
-          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_RESOURCE_GROUP }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
       run: |
         az keyvault network-rule add `
           --name ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh
@@ -73,6 +74,7 @@ jobs:
       run: |
         az keyvault network-rule remove `
           --name ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,10 +64,12 @@ jobs:
     - name: Get NuGet API key from Key Vault
       id: get-api-key
       run: |
-        $env:AZURE_SUBSCRIPTION_ID = "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-        $env:KEY_VAULT_NAME = "${{ secrets.KEY_VAULT_NAME }}"
         . .\digitalworkplace-workflows\scripts\get-secret.ps1
-        Get-Secret -secretName "github-publishing-nuget-api-key" -outputName "nuget-api-key"
+        Get-Secret `
+          -subscriptionId ${{ secrets.AZURE_SUBSCRIPTION_ID }} `
+          -keyVaultName ${{ secrets.KEY_VAULT_NAME }} `
+          -secretName "github-publishing-nuget-api-key" `
+          -outputName "nuget-api-key"
       shell: pwsh
 
     - name: Remove runner's IP address from Key Vault
@@ -92,13 +94,13 @@ jobs:
       run: |
         $signedFileName = (Get-ChildItem -Recurse -Path signed -Filter *.nupkg | Select-Object -Property Name -First 1).Name
         Write-Host "Signed file name found: $signedFileName"
-        Write-Output "$fileName=$signedFileName" >> $env:GITHUB_OUTPUT
+        Write-Output "fileName=$signedFileName" >> $env:GITHUB_OUTPUT
       shell: pwsh
 
     - name: Push Package Dry Run
       if: inputs.dry_run == true
       run: |
-        $signedFileName = ${{ steps.find-signed-package.outputs.fileName }}
+        $signedFileName = "${{ steps.find-signed-package.outputs.fileName }}"
         Write-Host "Signed file name (confirmation): $signedFileName"
         Write-Host "Dry-run enabled. Not pushing to NuGet."
 
@@ -116,7 +118,7 @@ jobs:
     - name: Push Package
       if: inputs.dry_run == false
       run: |
-        $signedFileName = ${{ steps.find-signed-package.outputs.fileName }}
+        $signedFileName = "${{ steps.find-signed-package.outputs.fileName }}"
         nuget push signed/$signedFileName `
           -Source https://api.nuget.org/v3/index.json `
           -ApiKey ${{ steps.get-api-key.outputs.nuget-api-key }} `

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -50,16 +50,11 @@ jobs:
         tenant-id: ${{ secrets.AAD_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Upgrade azure cli
-      run: |
-        az upgrade
-      shell: pwsh
-
     - name: Allow runner's IP address in Key Vault
       run: |
         az keyvault network-rule add `
           --name ${{ secrets.KEY_VAULT_NAME }} `
-          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_RESOURCE_GROUP }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh
@@ -108,7 +103,7 @@ jobs:
       run: |
         az keyvault network-rule remove `
           --name ${{ secrets.KEY_VAULT_NAME }} `
-          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_RESOURCE_GROUP }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -59,6 +59,7 @@ jobs:
       run: |
         az keyvault network-rule add `
           --name ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -108,6 +108,7 @@ jobs:
       run: |
         az keyvault network-rule remove `
           --name ${{ secrets.KEY_VAULT_NAME }} `
+          --resource-group ${{ secrets.KEY_VAULT_NAME }} `
           --ip-address ${{ steps.ip-address.outputs.ip-address }} `
           --output none
       shell: pwsh

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -50,6 +50,11 @@ jobs:
         tenant-id: ${{ secrets.AAD_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+    - name: Upgrade azure cli
+      run: |
+        az upgrade
+      shell: pwsh
+
     - name: Allow runner's IP address in Key Vault
       run: |
         az keyvault network-rule add `


### PR DESCRIPTION
Creating a PR to fix sign and publish scripts.
Currently there is an issue for adding Kv N/W rule where the az cli command for this fails with error incorrect API version. A fix for this is provided as adding the resource group parameter into the az cli command (refer - https://github.com/Azure/azure-cli/issues/27147).
Added this parameter and the release is working as expected. Consumers need to add the new secret (KEY_VAULT_RESOURCE_GROUP) in their consuming pipeline.
Also, included earlier fixes for publish script.